### PR TITLE
Fix spider name in crawler's online tests

### DIFF
--- a/crawler/tests/online.py
+++ b/crawler/tests/online.py
@@ -38,7 +38,7 @@ class TestLinkSpider(TestCase):
         "crawlid\":\"abc12345\",\"url\":\"istresearch.com\",\"expires\":0,\""\
         "ts\":1461549923.7956631184,\"priority\":1,\"deny_regex\":null,\""\
         "cookie\":null,\"attrs\":null,\"appid\":\"test\",\"spiderid\":\""\
-        "link\",\"useragent\":null,\"deny_extensions\":null,\"maxdepth\":0}"
+        "test-spider\",\"useragent\":null,\"deny_extensions\":null,\"maxdepth\":0}"
 
     def setUp(self):
         self.settings = get_project_settings()


### PR DESCRIPTION
Because of the wrong spider name, a wrong redis directory ended up containing the queue key.
This way the spider was not crawling the provided link.